### PR TITLE
Set UTC timezone for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "testEnvironment": "node"
   },
   "scripts": {
-    "test": "jest ${1}",
-    "test-watch": "jest ${1} --watch",
+    "test": "TZ=UTC jest ${1}",
+    "test-watch": "TZ=UTC jest ${1} --watch",
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | coveralls",
     "lint": "tslint index.ts lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
     "build": "tsc",


### PR DESCRIPTION
When you run tests in environment with timezone different than UTC, test fails.
This PR sets UTC timezone for tests.