### PR TITLE
fix: use rdfjs/types instead of types/rdfjs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import { DataFactory } from "rdf-data-factory";
-import * as RDF from "rdf-js";
+import * as RDF from "@rdfjs/types";
 import {
   TypeHandlerBoolean,
   TypeHandlerDate,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "devDependencies": {
     "@types/jest": "^28.0.0",
-    "@types/n3": "^1.10.3",
+    "@types/n3": "^1.16.4",
     "coveralls": "^3.0.0",
     "jest": "^28.0.0",
     "jest-rdf": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -713,6 +713,13 @@
   dependencies:
     "@types/node" "*"
 
+"@rdfjs/types@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@rdfjs/types/-/types-1.1.0.tgz#098f180b7cccb03bb416c7b4d03baaa9d480e36b"
+  integrity sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==
+  dependencies:
+    "@types/node" "*"
+
 "@sinclair/typebox@^0.23.3":
   version "0.23.5"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.23.5.tgz#93f7b9f4e3285a7a9ade7557d9a8d36809cbc47d"
@@ -804,13 +811,13 @@
     jest-matcher-utils "^28.0.0"
     pretty-format "^28.0.0"
 
-"@types/n3@^1.10.3":
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/@types/n3/-/n3-1.10.3.tgz#8f295db172a29c4daeced360c9460d4e0603cc9a"
-  integrity sha512-eVw/weCi6JPooPTz7Zgezmdw5ypNE57Ep+SlxFhT75F0nL9snsu1TIpAMAqtzHvi7VKJKJbnuOxAy9jgFCXDTA==
+"@types/n3@^1.16.4":
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/@types/n3/-/n3-1.16.4.tgz#007f489eb848a6a8ac586b037b8eea281da5730f"
+  integrity sha512-6PmHRYCCdjbbBV2UVC/HjtL6/5Orx9ku2CQjuojucuHvNvPmnm6+02B18YGhHfvU25qmX2jPXyYPHsMNkn+w2w==
   dependencies:
+    "@rdfjs/types" "^1.1.0"
     "@types/node" "*"
-    rdf-js "^4.0.2"
 
 "@types/node@*":
   version "13.5.0"
@@ -2734,13 +2741,6 @@ rdf-isomorphic@^1.3.0:
     hash.js "^1.1.7"
     rdf-string "^1.6.0"
     rdf-terms "^1.7.0"
-
-rdf-js@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/rdf-js/-/rdf-js-4.0.2.tgz#f01510528bbfc6e004012b71a8a533896c4c4c10"
-  integrity sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==
-  dependencies:
-    "@rdfjs/types" "*"
 
 rdf-string@^1.6.0:
   version "1.6.0"


### PR DESCRIPTION
I've upgraded the n3 types as well in order to remove the last reference to `@types/rdf-js` in the lockfile.